### PR TITLE
[Release] 5.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ Joi.timezone().validate('Australia/Darwin');
 This library is tested for compatibility, and contains peer dependencies with the following versions. 
 
 
-| Version                                                        | @hapi/joi 16.x | joi 16.x | joi 17.x |
-|----------------------------------------------------------------|----------------|----------|----------|
-| [5.0.0](https://github.com/tjdavey/joi-tz/releases/tag/v5.0.0) |                | ✅        | ✅        |
-| [4.1.1](https://github.com/tjdavey/joi-tz/releases/tag/v4.1.1) |                | ✅        | ✅        |
-| [4.1.0](https://github.com/tjdavey/joi-tz/releases/tag/v4.1.0) |                | ✅        | ✅        |
-| [4.0.2](https://github.com/tjdavey/joi-tz/releases/tag/v4.0.2) | ✅              |          |          |
+| Version                                                        | @hapi/joi 16.x | joi 16.x | joi 17.x | Timezone Database                                       |
+|----------------------------------------------------------------|----------------|----------|----------|---------------------------------------------------------|
+| [5.0.1](https://github.com/tjdavey/joi-tz/releases/tag/v5.0.1) |                | ✅        | ✅        | [Luxon](https://moment.github.io/luxon) 3.5.x           |
+| [5.0.0](https://github.com/tjdavey/joi-tz/releases/tag/v5.0.0) |                | ✅        | ✅        | [Luxon](https://moment.github.io/luxon) 3.4.x           | 
+| [4.1.1](https://github.com/tjdavey/joi-tz/releases/tag/v4.1.1) |                | ✅        | ✅        | [Moment-Timezone](https://momentjs.com/timezone/) 0.5.x | 
+| [4.1.0](https://github.com/tjdavey/joi-tz/releases/tag/v4.1.0) |                | ✅        | ✅        | [Moment-Timezone](https://momentjs.com/timezone/) 0.5.x |
+| [4.0.2](https://github.com/tjdavey/joi-tz/releases/tag/v4.0.2) | ✅              |          |          | [Moment-Timezone](https://momentjs.com/timezone/) 0.5.x |
 
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Ftjdavey%2Fjoi-tz.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Ftjdavey%2Fjoi-tz?ref=badge_large)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "joi-tz",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "joi-tz",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "luxon": "^3.4.4"
+        "luxon": "^3.5.0"
       },
       "devDependencies": {
         "coveralls-next": "^4.2.1",
@@ -5010,9 +5010,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
-      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
       "engines": {
         "node": ">=12"
       }
@@ -10424,9 +10424,9 @@
       }
     },
     "luxon": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
-      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ=="
     },
     "make-dir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-tz",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Timezone string validation for Joi 16.x or higher.",
   "keywords": [
     "joi",
@@ -35,7 +35,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "luxon": "^3.4.4"
+    "luxon": "^3.5.0"
   },
   "peerDependencies": {
     "joi": ">=16.1.8"


### PR DESCRIPTION
- Bump release version to 5.0.1
- Update Luxon to 3.5.0
- Update table in readme to include 5.0.1 + Timezone source information. 